### PR TITLE
fix: add link to cloudflared config

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ echo "Tunnel ID: $TUNNEL_ID"
 nano /etc/cloudflared/config.yml
 ~~~
 
-Paste the Cloudflare configuration (check Cloudflare Tunnel Configuration) and replace:
+Paste the Cloudflare configuration (check [Cloudflare Tunnel Configuration](https://github.com/sfnemis/proxmox-traefikproxy-cloudflaretunnel/blob/main/etc/cloudflared/config.yml)) and replace:
 
 - `TUNNEL_ID` with **your tunnel ID**
 - `TRAEFIK_IP` with the **IP of your Traefik container**


### PR DESCRIPTION
This PR does the following:
- link to the cloudflare tunnel config

Fixes this issue https://github.com/sfnemis/proxmox-traefikproxy-cloudflaretunnel/issues/6